### PR TITLE
add `generate_error_vector` and `generate_polynomial`

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -447,6 +447,45 @@ pub fn generate_error_vector(
     (elements, current_n)
 }
 
+/// Generates a polynomial sampled from the Centered Binomial Distribution (CBD).
+///
+/// This function derives a pseudo-random byte stream using `prf_3` with the given
+/// `sigma` and `n` as input, then maps the output to a polynomial using the CBD function.
+///
+/// # Arguments
+/// 
+/// * `sigma` - A vector of bytes serving as a seed for pseudo-random generation.
+/// * `eta` - The parameter controlling the shape of the binomial distribution.
+/// * `n` - A unique identifier (byte) for domain separation in the PRF.
+/// * `poly_size` - The degree of the polynomial.
+///
+/// # Returns
+/// 
+/// * A tuple containing:
+///   - A `Polynomial<i64>` sampled from the centered binomial distribution.
+///   - The updated `n + 1`, ensuring unique PRF inputs across calls.
+///
+/// # Example
+/// ```
+/// use ml_kem::utils::generate_polynomial;
+///
+/// let sigma = vec![0u8; 32]; // Example seed
+/// let eta = 3;
+/// let n = 0;
+/// let poly_size = 256;
+///
+/// let (poly, new_n) = generate_polynomial(sigma, eta, n, poly_size);
+///
+/// assert_eq!(new_n, 1);
+/// assert_eq!(poly.coeffs().len(), poly_size);
+/// ```
+///
+/// # Notes
+/// - `prf_3` produces 192 bytes, and for cbd we require eta*poly_size/4 = 192, the `prf` output length.
+/// - The value of `n` should be unique per call to ensure distinct polynomials.
+///
+/// # Panics
+/// - This function panics if `cbd` asserts that the input byte length is incorrect.
 pub fn generate_polynomial(
     sigma: Vec<u8>,
     eta: usize,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -402,3 +402,58 @@ pub fn cbd(input_bytes: Vec<u8>, eta: usize, n:usize) -> Polynomial<i64> {
 	}
 	Polynomial::new(coefficients)
 }
+
+/// Generate a random error vector, an element of a rank k module over R_q
+///
+/// # Arguments
+/// 
+/// * `sigma` - the std. deviation for the prf function
+/// * `eta` - the upper/lower bound for the centered binomial distribution
+/// * `n` - a byte
+/// * `poly_size` - the degree of the polynomials
+///
+/// # Returns
+/// 
+/// * (Vec<Polynomial<i64>>, u8) - the vector of polynomials and the current byte value `n`
+///
+/// # Example
+/// ```
+/// use ml_kem::utils::generate_error_vector;
+/// let sigma = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22];
+/// let eta = 24;
+/// let n = 0x01;
+/// let k = 3;
+/// let poly_size = 32;
+/// let (v,n) = generate_error_vector(sigma,eta,n,k,poly_size);
+/// assert_eq!(v.len(),3);
+/// ```
+pub fn generate_error_vector(
+    sigma: Vec<u8>,
+    eta: usize,
+    n: u8,
+    k: usize,
+    poly_size: usize
+) -> (Vec<Polynomial<i64>>, u8) {
+    let mut elements = vec![Polynomial::new(vec![]); k];
+    let mut current_n = n;
+
+    for i in 0..k {
+        let prf_output = prf_3(sigma.clone(), current_n);
+		assert_eq!(eta*poly_size/4, prf_output.len(), "eta*poly_size/4 must be 192 (prf output length)");
+        elements[i] = cbd(prf_output, eta, poly_size);
+        current_n += 1;
+    }
+
+    (elements, current_n)
+}
+
+pub fn generate_polynomial(
+    sigma: Vec<u8>,
+    eta: usize,
+    n: u8,
+    poly_size: usize
+) -> (Polynomial<i64>, u8) {
+    let prf_output = prf_3(sigma, n);
+    let poly = cbd(prf_output, eta, poly_size);
+    (poly, n + 1)
+}


### PR DESCRIPTION
these functions use the `prf` (psuedo-random number generator) and `cbd` (centered binomial distribution) functions to produce a random error vector and a random polynomial. 