### PR TITLE
add `ntt` in line with FIPS 203 pg. 24 (splitting into 128 quadratics via CRT)

### DIFF
--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -291,7 +291,7 @@ impl MLKEM {
 
         //compute v = intt(t_hat.y_hat) + e2 + mu
         let t_hat_dot_y_hat = mul_vec_simple(&t_hat, &y_hat, self.params.q, &self.params.f, self.params.omega);
-        let t_hat_dot_y_hat_from_ntt = poly_ntt(&t_hat_dot_y_hat, self.params.omega, self.params.n, self.params.q);
+        let t_hat_dot_y_hat_from_ntt = poly_ntt(&t_hat_dot_y_hat, self.params.zetas.clone());
         let v = polyadd(&polyadd(&t_hat_dot_y_hat_from_ntt, &e2, self.params.q, &self.params.f), &mu, self.params.q, &self.params.f);
 
         // compress vec u, poly v by compressing coeffs, then encode to bytes using params du, dv

--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -180,9 +180,9 @@ impl MLKEM {
         let (e, _prf_count) = generate_error_vector(sigma.clone(), self.params.eta_1, prf_count, self.params.k, self.params.n);
 
         // the NTT of s as an element of a rank k module over the polynomial ring
-        let s_hat = vec_ntt(&s,self.params.omega, self.params.n, self.params.q);
+        let s_hat = vec_ntt(&s, self.params.zetas.clone());
         // the NTT of e as an element of a rank k module over the polynomial ring
-        let e_hat = vec_ntt(&e,self.params.omega, self.params.n, self.params.q);
+        let e_hat = vec_ntt(&e, self.params.zetas.clone());
         // A_hat @ s_hat + e_hat
         let t_hat = add_vec(&mul_mat_vec_simple(&a_hat, &s_hat, self.params.q, &self.params.f, self.params.omega), &e_hat, self.params.q, &self.params.f);
 
@@ -279,11 +279,11 @@ impl MLKEM {
         let (e2, _prf_count) = generate_polynomial(r.clone(), self.params.eta_2, prf_count, self.params.n, None);
 
         // compute the NTT of the error vector y
-        let y_hat = vec_ntt(&y, self.params.omega, self.params.n, self.params.q);
+        let y_hat = vec_ntt(&y, self.params.zetas.clone());
 
         // compute u = intt(a_hat.T * y_hat) + e1
         let a_hat_t_y_hat = mul_mat_vec_simple(&a_hat_t, &y_hat, self.params.q, &self.params.f, self.params.omega);
-        let a_hat_t_y_hat_from_ntt = vec_intt(&a_hat_t_y_hat, self.params.omega, self.params.n, self.params.q);
+        let a_hat_t_y_hat_from_ntt = vec_intt(&a_hat_t_y_hat, self.params.zetas.clone());
         let u = add_vec(&a_hat_t_y_hat_from_ntt, &e1, self.params.q, &self.params.f);
 
         //decode the polynomial mu from the bytes m

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -965,6 +965,19 @@ pub fn poly_ntt(poly: &Polynomial<i64>, zetas: Vec<i64>) -> Polynomial<i64> {
 ///
 /// # Returns
 /// * A new `Polynomial<i64>` representing the inverse-transformed coefficients.
+///
+/// # Examples
+/// ```
+/// use ml_kem::utils::{generate_polynomial,poly_ntt,poly_intt};
+/// use ml_kem::utils::Parameters;
+/// let params = Parameters::default();
+/// let sigma = vec![0u8; 32];
+/// let b = 0;
+/// let (poly, _b) = generate_polynomial(sigma.clone(), params.eta_1, b, params.n, Some(3329));
+/// let poly_ntt_forward = poly_ntt(&poly, params.zetas.clone());
+/// let poly_recovered = poly_intt(&poly_ntt_forward, params.zetas.clone());
+/// assert_eq!(poly,poly_recovered);
+/// ```
 pub fn poly_intt(poly: &Polynomial<i64>, zetas: Vec<i64>) -> Polynomial<i64> {
     let mut coeffs = poly.coeffs().to_vec(); // Convert slice to Vec<i64>
     coeffs.resize(256, 0); // Ensure uniform length


### PR DESCRIPTION
this PR includes an NTT which is in line with what is outlined starting on pg. 24 in the FIPS 203 final standard document:

[https://csrc.nist.gov/pubs/fips/203/final](https://csrc.nist.gov/pubs/fips/203/final)

Essentially, we split the Kyber ring with `q=3329` and `n=256` into a sum of 128 quadratics, which allows us to use a 256th root of unity rather than rely on a 512th root of unity which doesn't exist, and would be required to perform the usual Cooley-Took or Gentleman-Sande NTT. 

We are effectively translating lines 175-198 of `kyber-py/ml_kem/polynomials/polynomials.py`.