### PR TITLE
implement `ntt` domain multiplication

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1062,7 +1062,7 @@ pub fn ntt_coefficient_multiplication(f_coeffs: Vec<i64>, g_coeffs: Vec<i64>, ze
 ///
 /// # Examples
 /// ```
-/// use ml_kem::utils::{generate_polynomial,poly_ntt, poly_intt, ntt_multiplication};
+/// use ml_kem::utils::{mod_coeffs,generate_polynomial,poly_ntt, poly_intt, ntt_multiplication};
 /// use ml_kem::utils::Parameters;
 /// use ring_lwe::utils::polymul;
 /// let params = Parameters::default();
@@ -1070,7 +1070,7 @@ pub fn ntt_coefficient_multiplication(f_coeffs: Vec<i64>, g_coeffs: Vec<i64>, ze
 /// let b = 0;
 /// let (p0, _b) = generate_polynomial(sigma.clone(), params.eta_1, b, params.n, Some(3329));
 /// let (p1, _b) = generate_polynomial(sigma.clone(), params.eta_1, b, params.n, Some(3329));
-/// let p0_p1 = polymul(&p0, &p1, 3329, &params.f);
+/// let p0_p1 = mod_coeffs(polymul(&p0, &p1, 3329, &params.f), 3329);
 /// let p0_ntt = poly_ntt(&p0, params.zetas.clone());
 /// let p1_ntt = poly_ntt(&p1, params.zetas.clone());
 /// let p0_ntt_p1_ntt = ntt_multiplication(p0_ntt, p1_ntt, params.zetas.clone());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -62,6 +62,16 @@ impl Default for Parameters {
     }
 }
 
+/// function to ensure coefficients are in [0,q-1] after taking remainders
+pub fn mod_coeffs(poly: Polynomial<i64>, q: i64) -> Polynomial<i64> {
+	let coeffs = poly.coeffs();
+	let mut mod_coeffs = vec![];
+	for i in 0..coeffs.len() {
+		mod_coeffs.push(coeffs[i].rem_euclid(q));
+	}
+	Polynomial::new(mod_coeffs)
+}
+
 /// Computes the bit-reversal of an unsigned `k`-bit integer `i`.
 ///
 /// The function reverses the order of the `k` least significant bits of `i`.
@@ -556,12 +566,7 @@ pub fn generate_polynomial(
     let poly = cbd(prf_output, eta, poly_size); // form the polynomial array from a centered binomial dist.
     //if a modulus is set, place coeffs in [0,q-1]
     if let Some(q) = q {
-        let coeffs = poly.coeffs();
-        let mut mod_coeffs = vec![];
-        for i in 0..coeffs.len() {
-            mod_coeffs.push(coeffs[i].rem_euclid(q));
-        }
-        return (Polynomial::new(mod_coeffs), b + 1);
+        return (mod_coeffs(poly,q), b + 1);
     }
     (poly, b + 1)
 }


### PR DESCRIPTION
this PR implements the NTT multiplication, so the product of polynomials which are already transformed under the NTT (number theoretic transform) as described on pg. 24 of the FIPS 203 standard paper. 

We essentially translate lines 248 - 289 of `kyber-py/ml_kem/polynomials/polynomials.py`. 