### PR TITLE
implement `mat_mul_vec_simple` and `mul_vec_simple` without `omega`

### DIFF
--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -1,5 +1,5 @@
 use crate::utils::{Parameters, hash_h, hash_g, generate_matrix_from_seed, generate_error_vector, generate_polynomial, encode_vector, vec_ntt, vec_intt, poly_ntt, decode_vector, encode_poly, decode_poly, decompress_poly, compress_poly, compress_vec};
-use module_lwe::utils::{gen_uniform_matrix,mul_mat_vec_simple,gen_small_vector,add_vec,mul_vec_simple};
+use module_lwe::utils::{gen_uniform_matrix,gen_small_vector,add_vec,mul_mat_vec_simple, mul_vec_simple};
 use module_lwe::encrypt::encrypt;
 use module_lwe::decrypt::decrypt;
 use ring_lwe::utils::{gen_binary_poly,polyadd};


### PR DESCRIPTION
These should mimic the operations in `module_lwe`, but not perform the fast polynomial multiplication using a `2n`th root of unity `omega`, but rather the `ntt` we have defined internally which does not rely on this due to splitting into 128 quadratic factors for `n=256`. 

This allows us to set `q=3329`.

Further, these operations are the component-wise multiplication in the transformed NTT domain; not the usual polynomial multiplication. This is important for later when we take inverses.