### PR TITLE
Implement `_encaps_internal` (Algorithm 17)

### DIFF
--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -289,11 +289,11 @@ impl MLKEM {
     /// };
     /// ```
     pub fn _encaps_internal(&self, ek: Vec<u8>, m: Vec<u8>) -> Result<(Vec<u8>, Vec<u8>), String> {
-        let (shared_key, r) = hash_g([m.clone(), hash_h(ek.clone())].concat());
+        let (shared_k, r) = hash_g([m.clone(), hash_h(ek.clone())].concat());
     
         let c = self._k_pke_encrypt(ek, m, r)?; // Propagate error with `?`
     
-        Ok((shared_key, c))
+        Ok((shared_k, c))
     }
 
 }

--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -269,4 +269,23 @@ impl MLKEM {
         (ek, dk)
     }
 
+    /// Uses the encapsulation key and randomness to generate a key and an
+    /// associated ciphertext following Algorithm 17 (FIPS 203)
+    /// 
+    /// # Arguemnts
+    /// * `ek` - (384*k+32)-byte encoded encapsulation key
+    /// * `m` - 32 bytes of randomness
+    /// # Returns
+    /// `(Vec<u8>, Vec<u8>)` - (32 byte shared key `K`, 32*(d_u*k+d_v)-byte ciphertext `c`)
+    /// # Examples
+    pub fn _encaps_internal(&self, ek: Vec<u8>, m: Vec<u8>){
+        let (K, r) = hash_g([m,hash_h(ek)].concat());
+
+        let c = self._k_pke_encrypt(ek, m, r).unwrap_or_else(|e| {
+            println!("Validation of encapsulation key failed: {}", e);
+        });
+
+        (K, c)
+    }
+
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,7 +14,13 @@ mod tests {
         let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
         let m = encode_poly(&compress_poly(&m_poly,1),1);
         let r = vec![0x01, 0x02, 0x03, 0x04];
-        let c = mlkem._k_pke_encrypt(ek_pke, m.clone(), r);
+    
+        // Handle encryption result properly
+        let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) {
+            Ok(ciphertext) => ciphertext,
+            Err(e) => panic!("Encryption failed: {}", e), // Make the test fail if encryption fails
+        };
+    
         let m_dec = mlkem._k_pke_decrypt(dk_pke, c);
         assert_eq!(m, m_dec);
     }


### PR DESCRIPTION
Implements `_encaps_internal`, Algorithm 17 of FIPS 203. 

Since `_k_pke_encrypt` throws an error in cases where they key length or encoding is wrong, we opt to handle this as an `Result<,>`, so we catch the error instead of `panic!`-ing. This is more graceful, and better practice (but requires `match` clauses when calling the functions). 

We propogate the error from `_k_pke_encrypt` to `_encaps_internal`.