### PR TITLE
Implement `_decaps_internal` (Algorithm 18)

### DIFF
--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -300,10 +300,24 @@ impl MLKEM {
     /// ciphertext following Algorithm 18 (FIPS 203)
     /// 
     /// # Arguments
-    /// `dk` - decapsulation key
+    /// `dk` - (768*k+96)-byte decapsulation key
     /// `c` - 32*(d_u*k+d_v)-byte ciphertext 
     /// # Returns
-    /// `Vec<u8> - decapulated key
+    /// `Vec<u8> - 32 byte decapulated shared key
+    /// # Examples
+    /// ```
+    /// let params = ml_kem::utils::Parameters::default();
+    /// let mlkem = ml_kem::ml_kem::MLKEM::new(params);
+    /// let d = vec![0x00; 32];
+    /// let z = vec![0x01; 32];
+    /// let m = vec![0x02; 32];
+    /// let (ek, dk) = mlkem._keygen_internal(d,z);
+    /// let (shared_k,c) = match mlkem._encaps_internal(ek,m) {
+    ///    Ok(ciphertext) => ciphertext,
+    ///    Err(e) => panic!("Encryption failed: {}", e), // Make the test fail if encryption fails
+    /// };
+    /// let shared_k = mlkem._decaps_internal(dk,c);
+    /// ```
     pub fn _decaps_internal(&self, dk: Vec<u8>, c: Vec<u8>) -> Result<Vec<u8>, String>{
 
         // NOTE: ML-KEM requires input validation before returning the result of
@@ -331,16 +345,16 @@ impl MLKEM {
             ));
         }
 
+        // Parse out data from dk
+        let dk_pke = &dk[0..384 * self.params.k];
+        let ek_pke = &dk[384 * self.params.k..768 * self.params.k + 32];
+        let h = &dk[768 * self.params.k + 32..768 * self.params.k + 64];
+        let z = &dk[768 * self.params.k + 64..];
+
         Ok(vec![]) // Placeholder return value
     }
 
     /*
-
-    # Parse out data from dk
-    dk_pke = dk[0 : 384 * self.k]
-    ek_pke = dk[384 * self.k : 768 * self.k + 32]
-    h = dk[768 * self.k + 32 : 768 * self.k + 64]
-    z = dk[768 * self.k + 64 :]
 
     # Ensure the hash-check passes
     if self._H(ek_pke) != h:

--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -314,9 +314,13 @@ impl MLKEM {
     /// let (ek, dk) = mlkem._keygen_internal(d,z);
     /// let (shared_k,c) = match mlkem._encaps_internal(ek,m) {
     ///    Ok(ciphertext) => ciphertext,
-    ///    Err(e) => panic!("Encryption failed: {}", e), // Make the test fail if encryption fails
+    ///    Err(e) => panic!("Encryption failed: {}", e),
     /// };
-    /// let shared_k = mlkem._decaps_internal(dk,c);
+    /// let shared_k_decaps = match mlkem._decaps_internal(dk,c) {
+    ///    Ok(decapsulated_shared_key) => decapsulated_shared_key,
+    ///    Err(e) => panic!("Encryption failed: {}", e),
+    /// };
+    /// assert_eq!(shared_k, shared_k_decaps);
     /// ```
     pub fn _decaps_internal(&self, dk: Vec<u8>, c: Vec<u8>) -> Result<Vec<u8>, String>{
 

--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -345,20 +345,21 @@ impl MLKEM {
             ));
         }
 
-        // Parse out data from dk
-        let dk_pke = &dk[0..384 * self.params.k];
-        let ek_pke = &dk[384 * self.params.k..768 * self.params.k + 32];
-        let h = &dk[768 * self.params.k + 32..768 * self.params.k + 64];
-        let z = &dk[768 * self.params.k + 64..];
+        // Parse out data from dk as Vec<u8>
+        let dk_pke = dk[0..384 * self.params.k].to_vec();
+        let ek_pke = dk[384 * self.params.k..768 * self.params.k + 32].to_vec();
+        let h = dk[768 * self.params.k + 32..768 * self.params.k + 64].to_vec();
+        let z = dk[768 * self.params.k + 64..].to_vec();
+
+        // Ensure the hash-check passes
+        if hash_h(ek_pke) != h{
+            return Err("hash check failed".to_string());
+        }
 
         Ok(vec![]) // Placeholder return value
     }
 
     /*
-
-    # Ensure the hash-check passes
-    if self._H(ek_pke) != h:
-        raise ValueError("hash check failed")
 
     # Decrypt the ciphertext
     m_prime = self._k_pke_decrypt(dk_pke, c)

--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -305,26 +305,36 @@ impl MLKEM {
     /// # Returns
     /// `Vec<u8> - decapulated key
     pub fn _decaps_internal(&self, dk: Vec<u8>, c: Vec<u8>) -> Result<Vec<u8>, String>{
+
+        // NOTE: ML-KEM requires input validation before returning the result of
+        // decapsulation. These are performed by the following three checks:
+        //
+        // 1) Ciphertext type check: the byte length of c must be correct
+        // 2) Decapsulation type check: the byte length of dk must be correct
+        // 3) Hash check: a hash of the internals of the dk must match
+        //
+        // Unlike encaps, these are easily performed in the kem decaps
+
+        if c.len() != 32 * (self.params.du * self.params.k + self.params.dv) {
+            return Err(format!(
+                "ciphertext type check failed. Expected {} bytes and obtained {}",
+                32 * (self.params.du * self.params.k + self.params.dv),
+                c.len()
+            ));
+        }
+
+        if dk.len() != 768 * self.params.k + 96{
+            return Err(format!(
+                "decapsulation type check failed. Expected {} bytes and obtained {}",
+                768 * self.params.k + 96,
+                dk.len()
+            ));
+        }
+
         Ok(vec![]) // Placeholder return value
     }
 
     /*
-    # NOTE: ML-KEM requires input validation before returning the result of
-    # decapsulation. These are performed by the following three checks:
-    #
-    # 1) Ciphertext type check: the byte length of c must be correct
-    # 2) Decapsulation type check: the byte length of dk must be correct
-    # 3) Hash check: a hash of the internals of the dk must match
-
-    # Unlike encaps, these are easily performed in the kem decaps
-    if len(c) != 32 * (self.du * self.k + self.dv):
-        raise ValueError(
-            f"ciphertext type check failed. Expected {32 * (self.du * self.k + self.dv)} bytes and obtained {len(c)}"
-        )
-    if len(dk) != 768 * self.k + 96:
-        raise ValueError(
-            f"decapsulation type check failed. Expected {768 * self.k + 96} bytes and obtained {len(dk)}"
-        )
 
     # Parse out data from dk
     dk_pke = dk[0 : 384 * self.k]

--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -376,7 +376,7 @@ impl MLKEM {
         // performed in constant time
         let shared_k = select_bytes(&k_bar, &k_prime, c == c_prime);
 
-        Ok(shared_k) // Placeholder return value
+        Ok(shared_k)
     }
 
 }

--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -296,4 +296,63 @@ impl MLKEM {
         Ok((shared_k, c))
     }
 
+    /// Uses the decapsulation key to produce a shared secret key from a
+    /// ciphertext following Algorithm 18 (FIPS 203)
+    /// 
+    /// # Arguments
+    /// `dk` - decapsulation key
+    /// `c` - 32*(d_u*k+d_v)-byte ciphertext 
+    /// # Returns
+    /// `Vec<u8> - decapulated key
+    pub fn _decaps_internal(&self, dk: Vec<u8>, c: Vec<u8>) -> Result<Vec<u8>, String>{
+        Ok(vec![]) // Placeholder return value
+    }
+
+    /*
+    # NOTE: ML-KEM requires input validation before returning the result of
+    # decapsulation. These are performed by the following three checks:
+    #
+    # 1) Ciphertext type check: the byte length of c must be correct
+    # 2) Decapsulation type check: the byte length of dk must be correct
+    # 3) Hash check: a hash of the internals of the dk must match
+
+    # Unlike encaps, these are easily performed in the kem decaps
+    if len(c) != 32 * (self.du * self.k + self.dv):
+        raise ValueError(
+            f"ciphertext type check failed. Expected {32 * (self.du * self.k + self.dv)} bytes and obtained {len(c)}"
+        )
+    if len(dk) != 768 * self.k + 96:
+        raise ValueError(
+            f"decapsulation type check failed. Expected {768 * self.k + 96} bytes and obtained {len(dk)}"
+        )
+
+    # Parse out data from dk
+    dk_pke = dk[0 : 384 * self.k]
+    ek_pke = dk[384 * self.k : 768 * self.k + 32]
+    h = dk[768 * self.k + 32 : 768 * self.k + 64]
+    z = dk[768 * self.k + 64 :]
+
+    # Ensure the hash-check passes
+    if self._H(ek_pke) != h:
+        raise ValueError("hash check failed")
+
+    # Decrypt the ciphertext
+    m_prime = self._k_pke_decrypt(dk_pke, c)
+
+    # Re-encrypt the recovered message
+    K_prime, r_prime = self._G(m_prime + h)
+    K_bar = self._J(z + c)
+
+    # Here the public encapsulation key is read from the private
+    # key and so we never expect this to fail the TypeCheck or
+    # ModulusCheck
+    c_prime = self._k_pke_encrypt(ek_pke, m_prime, r_prime)
+
+    # If c != c_prime, return K_bar as garbage
+    # WARNING: for proper implementations, it is absolutely
+    # vital that the selection between the key and garbage is
+    # performed in constant time
+    return select_bytes(K_bar, K_prime, c == c_prime)
+    */
+
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,6 +56,30 @@ impl Default for Parameters {
     }
 }
 
+/// Selects between the bytes in `a` or `b` based on `cond`.
+///
+/// If `cond` is `false`, returns `a`. If `cond` is `true`, returns `b`.
+///
+/// # Examples
+/// ```
+/// use ml_kem::utils::select_bytes;
+/// let a = vec![10, 20, 30];
+/// let b = vec![100, 110, 120];
+///
+/// assert_eq!(select_bytes(&a, &b, false), a);
+/// assert_eq!(select_bytes(&a, &b, true), b);
+/// ```
+pub fn select_bytes(a: &[u8], b: &[u8], cond: bool) -> Vec<u8> {
+    assert_eq!(a.len(), b.len(), "Input slices must have the same length");
+
+    let cw = if cond { 0xFF } else { 0x00 };
+
+    a.iter()
+        .zip(b.iter())
+        .map(|(&a_byte, &b_byte)| a_byte ^ (cw & (a_byte ^ b_byte)))
+        .collect()
+}
+
 /// function to ensure coefficients are in [0,q-1] after taking remainders
 /// # Arguments
 /// * `poly` - polynomial to mod


### PR DESCRIPTION
implement Algorithm 18 of FIPS 203, `_decaps_internal` to decapsulate a shared key `K`. 

we needed to add a `select_bytes` method to select bytes from either of two byte arrays based on a comparison.