### PR TITLE
remove pass by reference [pg. 6, FIPS 203]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2021"
 
 [dependencies]
 polynomial-ring = "0.5.0"
-module-lwe = "0.1.4"
-ring-lwe = "0.1.7"
 ntt = "0.1.9"
 rs_sha3_256 = "0.1.2"
 rs_sha3_512 = "0.1.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use ml_kem::ml_kem::MLKEM;
 use ml_kem::parameters::Parameters;
 use ml_kem::utils::{encode_poly,compress_poly};
-use ring_lwe::utils::gen_uniform_poly;
+use polynomial_ring::Polynomial;
 mod tests;
 
 fn main() {
@@ -12,7 +12,9 @@ fn main() {
     mlkem.set_drbg_seed(vec![0x42; 48]); // Example 48-byte seed
     let d = (mlkem.params.random_bytes)(32, mlkem.drbg.as_mut());
     let (ek_pke, dk_pke) = mlkem._k_pke_keygen(d); // Generate public and private keys for PKE
-    let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None); //random message polynomial
+    let rand_bytes_os = (mlkem.params.random_bytes)(mlkem.params.n, None); //get random bytes from OS
+    let rand_coeffs: Vec<i64> = rand_bytes_os.into_iter().map(|byte| byte as i64).collect(); // convert to i64 array
+    let m_poly = Polynomial::new(rand_coeffs); // create a polynomial from the random coefficients
     let m = encode_poly(compress_poly(m_poly,1),1); // compress and encode the message polynomial
     let r = vec![0x01, 0x02, 0x03, 0x04]; // Example random bytes for encryption
     let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) { //perform encryption, handling potential errors

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
     let d = (mlkem.params.random_bytes)(32, mlkem.drbg.as_mut());
     let (ek_pke, dk_pke) = mlkem._k_pke_keygen(d); // Generate public and private keys for PKE
     let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None); //random message polynomial
-    let m = encode_poly(&compress_poly(&m_poly,1),1); // compress and encode the message polynomial
+    let m = encode_poly(compress_poly(m_poly,1),1); // compress and encode the message polynomial
     let r = vec![0x01, 0x02, 0x03, 0x04]; // Example random bytes for encryption
     let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) { //perform encryption, handling potential errors
         Ok(ciphertext) => ciphertext,

--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -104,12 +104,14 @@ impl MLKEM {
     /// ```
     /// use ml_kem::ml_kem::MLKEM;
     /// use ml_kem::utils::{encode_poly,compress_poly, generate_polynomial};
+    /// use polynomial_ring::Polynomial;
     /// let params = ml_kem::parameters::Parameters::mlkem512();
     /// let mlkem = MLKEM::new(params);
-    /// use ring_lwe::utils::gen_uniform_poly;
     /// let d = vec![0x01, 0x02, 0x03, 0x04];
     /// let (ek_pke, _dk_pke) = mlkem._k_pke_keygen(d);
-    /// let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
+    /// let rand_bytes_os = (mlkem.params.random_bytes)(mlkem.params.n, None);
+    /// let rand_coeffs: Vec<i64> = rand_bytes_os.into_iter().map(|byte| byte as i64).collect();
+    /// let m_poly = Polynomial::new(rand_coeffs);
     /// let m = encode_poly(compress_poly(m_poly,1),1);
     /// let r = vec![0x01, 0x02, 0x03, 0x04];
     /// let c = mlkem._k_pke_encrypt(ek_pke, m, r);
@@ -197,12 +199,14 @@ impl MLKEM {
     /// ```
     /// use ml_kem::ml_kem::MLKEM;
     /// use ml_kem::utils::{encode_poly,generate_polynomial,compress_poly};
-    /// use ring_lwe::utils::gen_uniform_poly;
+    /// use polynomial_ring::Polynomial;
     /// let params = ml_kem::parameters::Parameters::mlkem512();
     /// let mlkem = MLKEM::new(params);
     /// let d = vec![0x01, 0x02, 0x03, 0x04];
     /// let (ek_pke, dk_pke) = mlkem._k_pke_keygen(d);
-    /// let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
+    /// let rand_bytes_os = (mlkem.params.random_bytes)(mlkem.params.n, None);
+    /// let rand_coeffs: Vec<i64> = rand_bytes_os.into_iter().map(|byte| byte as i64).collect();
+    /// let m_poly = Polynomial::new(rand_coeffs);
     /// let m = encode_poly(compress_poly(m_poly,1),1);
     /// let r = vec![0x01, 0x02, 0x03, 0x04];
     /// let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) {

--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -68,7 +68,7 @@ impl MLKEM {
         // the NTT of e as an element of a rank k module over the polynomial ring
         let e_hat = vec_ntt(e, self.params.zetas.clone());
         // A_hat @ s_hat + e_hat
-        let a_hat_s_hat = mul_mat_vec_simple(a_hat, s_hat, self.params.q, self.params.f.clone(), self.params.zetas.clone());
+        let a_hat_s_hat = mul_mat_vec_simple(a_hat, s_hat.clone(), self.params.q, self.params.f.clone(), self.params.zetas.clone());
         let t_hat = add_vec(a_hat_s_hat, e_hat, self.params.q, self.params.f.clone());
 
         // Encode the keys
@@ -110,7 +110,7 @@ impl MLKEM {
     /// let d = vec![0x01, 0x02, 0x03, 0x04];
     /// let (ek_pke, _dk_pke) = mlkem._k_pke_keygen(d);
     /// let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
-    /// let m = encode_poly(&compress_poly(&m_poly,1),1);
+    /// let m = encode_poly(compress_poly(m_poly,1),1);
     /// let r = vec![0x01, 0x02, 0x03, 0x04];
     /// let c = mlkem._k_pke_encrypt(ek_pke, m, r);
     /// ```
@@ -141,10 +141,10 @@ impl MLKEM {
         let rho = rho_slice.to_vec();
 
         // decode the vector of polynomials from bytes
-        let t_hat = decode_vector(t_hat_bytes, self.params.k, 12);
+        let t_hat = decode_vector(t_hat_bytes.clone(), self.params.k, 12);
 
         // check that t_hat has been canonically encoded
-        if encode_vector(t_hat,12) != t_hat_bytes {
+        if encode_vector(t_hat.clone(),12) != t_hat_bytes {
             return Err("Modulus check failed: t_hat does not encode correctly".to_string());
         }
 
@@ -161,18 +161,18 @@ impl MLKEM {
         let y_hat = vec_ntt(y, self.params.zetas.clone());
 
         // compute u = intt(a_hat.T * y_hat) + e1
-        let a_hat_t_y_hat = mul_mat_vec_simple(a_hat_t, y_hat, self.params.q, self.params.f, self.params.zetas.clone());
+        let a_hat_t_y_hat = mul_mat_vec_simple(a_hat_t, y_hat.clone(), self.params.q, self.params.f.clone(), self.params.zetas.clone());
         let a_hat_t_y_hat_intt = vec_intt(a_hat_t_y_hat, self.params.zetas.clone());
-        let u = add_vec(a_hat_t_y_hat_intt, e1, self.params.q, self.params.f);
+        let u = add_vec(a_hat_t_y_hat_intt, e1, self.params.q, self.params.f.clone());
 
         //decode the polynomial mu from the bytes m
         let mu = decompress_poly(decode_poly(m, 1),1);
 
         //compute v = intt(t_hat.y_hat) + e2 + mu
-        let t_hat_dot_y_hat = mul_vec_simple(t_hat, y_hat, self.params.q, self.params.f, self.params.zetas.clone());
+        let t_hat_dot_y_hat = mul_vec_simple(t_hat, y_hat, self.params.q, self.params.f.clone(), self.params.zetas.clone());
         let t_hat_dot_y_hat_intt = poly_intt(t_hat_dot_y_hat, self.params.zetas.clone());
-        let t_hat_dot_y_hat_intt_plus_e2 = polyadd(t_hat_dot_y_hat_intt.clone(), e2.clone(), self.params.q, self.params.f);
-        let v = polyadd(t_hat_dot_y_hat_intt_plus_e2, mu, self.params.q, self.params.f);
+        let t_hat_dot_y_hat_intt_plus_e2 = polyadd(t_hat_dot_y_hat_intt.clone(), e2.clone(), self.params.q, self.params.f.clone());
+        let v = polyadd(t_hat_dot_y_hat_intt_plus_e2, mu, self.params.q, self.params.f.clone());
 
         // compress vec u, poly v by compressing coeffs, then encode to bytes using params du, dv
         let c1 = encode_vector(compress_vec(u,self.params.du),self.params.du);
@@ -203,7 +203,7 @@ impl MLKEM {
     /// let d = vec![0x01, 0x02, 0x03, 0x04];
     /// let (ek_pke, dk_pke) = mlkem._k_pke_keygen(d);
     /// let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
-    /// let m = encode_poly(&compress_poly(&m_poly,1),1);
+    /// let m = encode_poly(compress_poly(m_poly,1),1);
     /// let r = vec![0x01, 0x02, 0x03, 0x04];
     /// let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) {
     ///    Ok(ciphertext) => ciphertext,
@@ -231,9 +231,9 @@ impl MLKEM {
         let u_hat = vec_ntt(u, self.params.zetas.clone());
 
         // compute w = v - (s_hat.u_hat).from_ntt()
-        let s_hat_dot_u_hat = mul_vec_simple(s_hat, u_hat, self.params.q, self.params.f, self.params.zetas.clone());
+        let s_hat_dot_u_hat = mul_vec_simple(s_hat, u_hat, self.params.q, self.params.f.clone(), self.params.zetas.clone());
         let s_hat_dot_u_hat_intt = poly_intt(s_hat_dot_u_hat, self.params.zetas.clone());
-        let w = polysub(v, s_hat_dot_u_hat_intt, self.params.q, self.params.f);
+        let w = polysub(v, s_hat_dot_u_hat_intt, self.params.q, self.params.f.clone());
 
         // compress and encode w to get message m
         let m = encode_poly(compress_poly(w,1),1);

--- a/src/ml_kem.rs
+++ b/src/ml_kem.rs
@@ -378,7 +378,7 @@ impl MLKEM {
         // WARNING: for proper implementations, it is absolutely
         // vital that the selection between the key and garbage is
         // performed in constant time
-        let shared_k = select_bytes(&k_bar, &k_prime, c == c_prime);
+        let shared_k = select_bytes(k_bar, k_prime, c == c_prime);
 
         Ok(shared_k)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -36,7 +36,7 @@ mod tests {
         let d = vec![0x01, 0x02, 0x03, 0x04];
         let (ek_pke, dk_pke) = mlkem._k_pke_keygen(d);
         let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
-        let m = encode_poly(&compress_poly(&m_poly,1),1);
+        let m = encode_poly(compress_poly(m_poly,1),1);
         let r = vec![0x01, 0x02, 0x03, 0x04];
         let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) {
             Ok(ciphertext) => ciphertext,
@@ -54,7 +54,7 @@ mod tests {
         let d = vec![0x01, 0x02, 0x03, 0x04];
         let (ek_pke, dk_pke) = mlkem._k_pke_keygen(d);
         let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
-        let m = encode_poly(&compress_poly(&m_poly,1),1);
+        let m = encode_poly(compress_poly(m_poly,1),1);
         let r = vec![0x01, 0x02, 0x03, 0x04];
         let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) {
             Ok(ciphertext) => ciphertext,
@@ -72,7 +72,7 @@ mod tests {
         let d = vec![0x01, 0x02, 0x03, 0x04];
         let (ek_pke, dk_pke) = mlkem._k_pke_keygen(d);
         let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
-        let m = encode_poly(&compress_poly(&m_poly,1),1);
+        let m = encode_poly(compress_poly(m_poly,1),1);
         let r = vec![0x01, 0x02, 0x03, 0x04];
         let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) {
             Ok(ciphertext) => ciphertext,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@ mod tests {
     use ml_kem::parameters::Parameters;
     use ml_kem::utils::{encode_poly,compress_poly};
 	use ml_kem::ml_kem::MLKEM;
-    use ring_lwe::utils::gen_uniform_poly;
+    use polynomial_ring::Polynomial;
 
     // test for setting the DRBG seed
     #[test]
@@ -35,7 +35,9 @@ mod tests {
         let mlkem = MLKEM::new(params);
         let d = vec![0x01, 0x02, 0x03, 0x04];
         let (ek_pke, dk_pke) = mlkem._k_pke_keygen(d);
-        let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
+        let rand_bytes_os = (mlkem.params.random_bytes)(mlkem.params.n, None);
+        let rand_coeffs: Vec<i64> = rand_bytes_os.into_iter().map(|byte| byte as i64).collect();
+        let m_poly = Polynomial::new(rand_coeffs);
         let m = encode_poly(compress_poly(m_poly,1),1);
         let r = vec![0x01, 0x02, 0x03, 0x04];
         let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) {
@@ -53,7 +55,9 @@ mod tests {
         let mlkem = MLKEM::new(params);
         let d = vec![0x01, 0x02, 0x03, 0x04];
         let (ek_pke, dk_pke) = mlkem._k_pke_keygen(d);
-        let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
+        let rand_bytes_os = (mlkem.params.random_bytes)(mlkem.params.n, None);
+        let rand_coeffs: Vec<i64> = rand_bytes_os.into_iter().map(|byte| byte as i64).collect();
+        let m_poly = Polynomial::new(rand_coeffs);
         let m = encode_poly(compress_poly(m_poly,1),1);
         let r = vec![0x01, 0x02, 0x03, 0x04];
         let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) {
@@ -71,7 +75,9 @@ mod tests {
         let mlkem = MLKEM::new(params);
         let d = vec![0x01, 0x02, 0x03, 0x04];
         let (ek_pke, dk_pke) = mlkem._k_pke_keygen(d);
-        let m_poly = gen_uniform_poly(mlkem.params.n, mlkem.params.q, None);
+        let rand_bytes_os = (mlkem.params.random_bytes)(mlkem.params.n, None);
+        let rand_coeffs: Vec<i64> = rand_bytes_os.into_iter().map(|byte| byte as i64).collect();
+        let m_poly = Polynomial::new(rand_coeffs);
         let m = encode_poly(compress_poly(m_poly,1),1);
         let r = vec![0x01, 0x02, 0x03, 0x04];
         let c = match mlkem._k_pke_encrypt(ek_pke, m.clone(), r) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,10 +17,10 @@ use num_traits::Zero;
 /// let a = vec![10, 20, 30];
 /// let b = vec![100, 110, 120];
 ///
-/// assert_eq!(select_bytes(&a, &b, false), a);
-/// assert_eq!(select_bytes(&a, &b, true), b);
+/// assert_eq!(select_bytes(a.clone(), b.clone(), false), a);
+/// assert_eq!(select_bytes(a.clone(), b.clone(), true), b);
 /// ```
-pub fn select_bytes(a: &[u8], b: &[u8], cond: bool) -> Vec<u8> {
+pub fn select_bytes(a: Vec<u8>, b: Vec<u8>, cond: bool) -> Vec<u8> {
     assert_eq!(a.len(), b.len(), "Input slices must have the same length");
 
     let cw = if cond { 0xFF } else { 0x00 };


### PR DESCRIPTION
we remove all values which are "passed by reference" in line with the FIPS 203 standard document on pg. 6. 

we clone values when necessary and pass them directly.

we also remove use of outside crates `module_lwe` and `ring_lwe` and use system random to generate random polynomials for testing.