### PR TITLE
add `criterion` benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 description = "MLKEM [512, 768, 1024] module-lattice key encapsulation mechanism following the FIPS 203 standard."
 license = "MIT"
-documentation = "https://docs.rs/module-lwe"
-homepage = "https://github.com/lattice-based-cryptography/module-lwe"
-repository = "https://github.com/lattice-based-cryptography/module-lwe"
+documentation = "https://docs.rs/ml-kem"
+homepage = "https://github.com/lattice-based-cryptography/ml-kem"
+repository = "https://github.com/lattice-based-cryptography/ml-kem"
 
 [dependencies]
 polynomial-ring = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "ml-kem"
 version = "0.1.0"
 edition = "2021"
+description = "MLKEM [512, 768, 1024] module-lattice key encapsulation mechanism following the FIPS 203 standard."
+license = "MIT"
+documentation = "https://docs.rs/module-lwe"
+homepage = "https://github.com/lattice-based-cryptography/module-lwe"
+repository = "https://github.com/lattice-based-cryptography/module-lwe"
 
 [dependencies]
 polynomial-ring = "0.5.0"
@@ -14,3 +19,21 @@ aes_ctr_drbg = "0.0.2"
 getrandom = "0.2"
 num-bigint = "0.4"
 num-traits = "0.2"
+
+[dev-dependencies]
+criterion = "0.5.1"
+
+[[bench]]
+name = "benchmark_keygen"
+path = "benches/benchmark_keygen.rs"
+harness = false
+
+[[bench]]
+name = "benchmark_encaps"
+path = "benches/benchmark_encaps.rs"
+harness = false
+
+[[bench]]
+name = "benchmark_decaps"
+path = "benches/benchmark_decaps.rs"
+harness = false

--- a/benches/benchmark_decaps.rs
+++ b/benches/benchmark_decaps.rs
@@ -1,0 +1,63 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use ml_kem::ml_kem::MLKEM;
+use ml_kem::parameters::Parameters;
+
+// benchmark decaps for 512
+fn bench_decaps_512(crit: &mut Criterion) {
+    let params = Parameters::mlkem512();
+    let mut mlkem = MLKEM::new(params);
+    let (ek, dk) = mlkem.keygen();
+    let (_shared_k,c) = match mlkem.encaps(ek) {
+        Ok(ciphertext) => ciphertext,
+        Err(e) => panic!("Encryption failed: {}", e),
+    };
+    crit.bench_function("decaps", |b| {
+        b.iter(|| {
+            match mlkem.decaps(dk.clone(),c.clone()) {
+                Ok(decapsulated_shared_key) => decapsulated_shared_key,
+                Err(e) => panic!("Decryption failed: {}", e),
+             }
+        })
+    });
+}
+
+// benchmark decaps for 768
+fn bench_decaps_768(crit: &mut Criterion) {
+    let params = Parameters::mlkem768();
+    let mut mlkem = MLKEM::new(params);
+    let (ek, dk) = mlkem.keygen();
+    let (_shared_k,c) = match mlkem.encaps(ek) {
+        Ok(ciphertext) => ciphertext,
+        Err(e) => panic!("Encryption failed: {}", e),
+    };
+    crit.bench_function("decaps", |b| {
+        b.iter(|| {
+            match mlkem.decaps(dk.clone(),c.clone()) {
+                Ok(decapsulated_shared_key) => decapsulated_shared_key,
+                Err(e) => panic!("Decryption failed: {}", e),
+             }
+        })
+    });
+}
+
+// benchmark decaps for 1024
+fn bench_decaps_1024(crit: &mut Criterion) {
+    let params = Parameters::mlkem1024();
+    let mut mlkem = MLKEM::new(params);
+    let (ek, dk) = mlkem.keygen();
+    let (_shared_k,c) = match mlkem.encaps(ek) {
+        Ok(ciphertext) => ciphertext,
+        Err(e) => panic!("Encryption failed: {}", e),
+    };
+    crit.bench_function("decaps", |b| {
+        b.iter(|| {
+            match mlkem.decaps(dk.clone(),c.clone()) {
+                Ok(decapsulated_shared_key) => decapsulated_shared_key,
+                Err(e) => panic!("Decryption failed: {}", e),
+             }
+        })
+    });
+}
+
+criterion_group!(benches, bench_decaps_512, bench_decaps_768, bench_decaps_1024);
+criterion_main!(benches);

--- a/benches/benchmark_decaps.rs
+++ b/benches/benchmark_decaps.rs
@@ -11,7 +11,7 @@ fn bench_decaps_512(crit: &mut Criterion) {
         Ok(ciphertext) => ciphertext,
         Err(e) => panic!("Encryption failed: {}", e),
     };
-    crit.bench_function("decaps", |b| {
+    crit.bench_function("decaps_512", |b| {
         b.iter(|| {
             match mlkem.decaps(dk.clone(),c.clone()) {
                 Ok(decapsulated_shared_key) => decapsulated_shared_key,
@@ -30,7 +30,7 @@ fn bench_decaps_768(crit: &mut Criterion) {
         Ok(ciphertext) => ciphertext,
         Err(e) => panic!("Encryption failed: {}", e),
     };
-    crit.bench_function("decaps", |b| {
+    crit.bench_function("decaps_768", |b| {
         b.iter(|| {
             match mlkem.decaps(dk.clone(),c.clone()) {
                 Ok(decapsulated_shared_key) => decapsulated_shared_key,
@@ -49,7 +49,7 @@ fn bench_decaps_1024(crit: &mut Criterion) {
         Ok(ciphertext) => ciphertext,
         Err(e) => panic!("Encryption failed: {}", e),
     };
-    crit.bench_function("decaps", |b| {
+    crit.bench_function("decaps_1024", |b| {
         b.iter(|| {
             match mlkem.decaps(dk.clone(),c.clone()) {
                 Ok(decapsulated_shared_key) => decapsulated_shared_key,

--- a/benches/benchmark_encaps.rs
+++ b/benches/benchmark_encaps.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use ml_kem::ml_kem::MLKEM;
 use ml_kem::parameters::Parameters;
 
-// benchmark keygen for 512
+// benchmark encaps for 512
 fn bench_encaps_512(c: &mut Criterion) {
     let params = Parameters::mlkem512();
     let mut mlkem = MLKEM::new(params);
@@ -17,7 +17,7 @@ fn bench_encaps_512(c: &mut Criterion) {
     });
 }
 
-// benchmark keygen for 768
+// benchmark encaps for 768
 fn bench_encaps_768(c: &mut Criterion) {
     let params = Parameters::mlkem768();
     let mut mlkem = MLKEM::new(params);
@@ -32,7 +32,7 @@ fn bench_encaps_768(c: &mut Criterion) {
     });
 }
 
-// benchmark keygen for 1024
+// benchmark encaps for 1024
 fn bench_encaps_1024(c: &mut Criterion) {
     let params = Parameters::mlkem1024();
     let mut mlkem = MLKEM::new(params);

--- a/benches/benchmark_encaps.rs
+++ b/benches/benchmark_encaps.rs
@@ -7,7 +7,7 @@ fn bench_encaps_512(c: &mut Criterion) {
     let params = Parameters::mlkem512();
     let mut mlkem = MLKEM::new(params);
     let (ek, _dk) = mlkem.keygen();
-    c.bench_function("encaps", |b| {
+    c.bench_function("encaps_512", |b| {
         b.iter(|| {
             match mlkem.encaps(ek.clone()) {
                 Ok(ciphertext) => ciphertext,
@@ -22,7 +22,7 @@ fn bench_encaps_768(c: &mut Criterion) {
     let params = Parameters::mlkem768();
     let mut mlkem = MLKEM::new(params);
     let (ek, _dk) = mlkem.keygen();
-    c.bench_function("encaps", |b| {
+    c.bench_function("encaps_768", |b| {
         b.iter(|| {
             match mlkem.encaps(ek.clone()) {
                 Ok(ciphertext) => ciphertext,
@@ -37,7 +37,7 @@ fn bench_encaps_1024(c: &mut Criterion) {
     let params = Parameters::mlkem1024();
     let mut mlkem = MLKEM::new(params);
     let (ek, _dk) = mlkem.keygen();
-    c.bench_function("encaps", |b| {
+    c.bench_function("encaps_1024", |b| {
         b.iter(|| {
             match mlkem.encaps(ek.clone()) {
                 Ok(ciphertext) => ciphertext,

--- a/benches/benchmark_encaps.rs
+++ b/benches/benchmark_encaps.rs
@@ -1,0 +1,51 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use ml_kem::ml_kem::MLKEM;
+use ml_kem::parameters::Parameters;
+
+// benchmark keygen for 512
+fn bench_encaps_512(c: &mut Criterion) {
+    let params = Parameters::mlkem512();
+    let mut mlkem = MLKEM::new(params);
+    let (ek, _dk) = mlkem.keygen();
+    c.bench_function("encaps", |b| {
+        b.iter(|| {
+            match mlkem.encaps(ek.clone()) {
+                Ok(ciphertext) => ciphertext,
+                Err(e) => panic!("Encryption failed: {}", e),
+            }
+        })
+    });
+}
+
+// benchmark keygen for 768
+fn bench_encaps_768(c: &mut Criterion) {
+    let params = Parameters::mlkem768();
+    let mut mlkem = MLKEM::new(params);
+    let (ek, _dk) = mlkem.keygen();
+    c.bench_function("encaps", |b| {
+        b.iter(|| {
+            match mlkem.encaps(ek.clone()) {
+                Ok(ciphertext) => ciphertext,
+                Err(e) => panic!("Encryption failed: {}", e),
+            }
+        })
+    });
+}
+
+// benchmark keygen for 1024
+fn bench_encaps_1024(c: &mut Criterion) {
+    let params = Parameters::mlkem1024();
+    let mut mlkem = MLKEM::new(params);
+    let (ek, _dk) = mlkem.keygen();
+    c.bench_function("encaps", |b| {
+        b.iter(|| {
+            match mlkem.encaps(ek.clone()) {
+                Ok(ciphertext) => ciphertext,
+                Err(e) => panic!("Encryption failed: {}", e),
+            }
+        })
+    });
+}
+
+criterion_group!(benches, bench_encaps_512, bench_encaps_768, bench_encaps_1024);
+criterion_main!(benches);

--- a/benches/benchmark_keygen.rs
+++ b/benches/benchmark_keygen.rs
@@ -1,0 +1,33 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use ml_kem::ml_kem::MLKEM;
+use ml_kem::parameters::Parameters;
+
+// benchmark keygen for 512
+fn bench_keygen_512(c: &mut Criterion) {
+    let params = Parameters::mlkem512();
+    let mut mlkem = MLKEM::new(params);
+    c.bench_function("keygen", |b| {
+        b.iter(|| mlkem.keygen())
+    });
+}
+
+// benchmark keygen for 768
+fn bench_keygen_768(c: &mut Criterion) {
+    let params = Parameters::mlkem768();
+    let mut mlkem = MLKEM::new(params);
+    c.bench_function("keygen", |b| {
+        b.iter(|| mlkem.keygen())
+    });
+}
+
+// benchmark keygen for 1024
+fn bench_keygen_1024(c: &mut Criterion) {
+    let params = Parameters::mlkem1024();
+    let mut mlkem = MLKEM::new(params);
+    c.bench_function("keygen", |b| {
+        b.iter(|| mlkem.keygen())
+    });
+}
+
+criterion_group!(benches, bench_keygen_512, bench_keygen_768, bench_keygen_1024);
+criterion_main!(benches);


### PR DESCRIPTION
add `criterion` benchmarking for `keygen`, `encaps`, and `decaps` functions for 512, 768, and 1024. 

the initial numbers are in the hundreds of microseconds, which is a few times faster than Python and a good start.