### PR TITLE
fix readme crates.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![example workflow](https://github.com/lattice-based-cryptography/ml-kem/actions/workflows/basic.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
-[![Crates.io](https://img.shields.io/crates/v/module-lwe.svg)](https://crates.io/crates/ml-kem)
+[![Crates.io](https://img.shields.io/crates/v/ml-kem.svg)](https://crates.io/crates/ml-kem)
 
 **Description**: Rust implementation of module-lattice key encapsulation mechanism (ML-KEM) as specified in FIPS 203. Includes all parameters sets (MLKEM512, MLKEM768, MLKEM1024).
 


### PR DESCRIPTION
it should be ml-kem, not module-lwe